### PR TITLE
Bump @bestsellerit/secret-injector from 1.0.3 to 2.0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ executors:
 
 
 orbs:
-  secret-injector: bestsellerit/secret-injector@1.0.3
+  secret-injector: bestsellerit/secret-injector@2.0.6
   slack: circleci/slack@3.4.2
 


### PR DESCRIPTION
Bump @bestsellerit/secret-injector from 1.0.3 to 2.0.6