### PR TITLE
Bump @circleci/slack from 3.4.2 to 4.10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,5 @@ executors:
 
 orbs:
   secret-injector: bestsellerit/secret-injector@1.0.3
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.10.1
 


### PR DESCRIPTION
Bump @circleci/slack from 3.4.2 to 4.10.1