### PR TITLE
Bump @gcr.io/cloudsql-docker/gce-proxy from 1.30.0 to 1.31.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: quay.io/jetstack/cert-manager-controller:v1.0.0
   gcp:
     docker:
-      - image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
+      - image: gcr.io/cloudsql-docker/gce-proxy:1.31.2
 
 
 orbs:


### PR DESCRIPTION
Bump @gcr.io/cloudsql-docker/gce-proxy from 1.30.0 to 1.31.2