### PR TITLE
Bump @quay.io/jetstack/cert-manager-controller from v1.0.0 to 608111629

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: linuxserver/rdesktop:version-b5ae438f
   cert:
     docker:
-      - image: quay.io/jetstack/cert-manager-controller:v1.0.0
+      - image: quay.io/jetstack/cert-manager-controller:608111629
   gcp:
     docker:
       - image: gcr.io/cloudsql-docker/gce-proxy:1.30.0


### PR DESCRIPTION
Bump @quay.io/jetstack/cert-manager-controller from v1.0.0 to 608111629